### PR TITLE
Updated ActivityForm.php to reflect changes made to OctoberCMS in build 184

### DIFF
--- a/classes/ActivityForm.php
+++ b/classes/ActivityForm.php
@@ -244,13 +244,13 @@ class ActivityForm extends WidgetBase
      */
     public function getFieldDepends($field)
     {
-        if (!$field->depends) {
+        if (!$field->dependsOn) {
             return;
         }
 
-        $depends = is_array($field->depends) ? $field->depends : [$field->depends];
-        $depends = htmlspecialchars(json_encode($depends), ENT_QUOTES, 'UTF-8');
-        return $depends;
+        $dependsOn = is_array($field->dependsOn) ? $field->dependsOn : [$field->dependsOn];
+        $dependsOn = htmlspecialchars(json_encode($dependsOn), ENT_QUOTES, 'UTF-8');
+        return $dependsOn;
     }
 
         /**


### PR DESCRIPTION
I don't know which build of October you guys are currently targeting, but build 184 changed one of the core classes. Backend\Classes\FormField has been changed such that the depends property is now dependsOn. The activity editing form was throwing exceptions because our sandbox is using the (currently) latest build. Other partners who install October fresh as they start working on their implementations will probably get the latest updates as well so this might be necessary for them even if you guys are currently sticking to an older build on DMA's end. Problem is, if you accept this pull into your master branch without updating your October install it will probably throw the same exceptions mine was because the class hasn't been updated on your end.

I'm going to stop updating our sandbox for now because I'm trying to get our demo working, but we may have to keep an eye out for things like this as the other partners start to install October fresh on their systems.
